### PR TITLE
feat(): improve mcdu reaction speed

### DIFF
--- a/src/include/appstate.cpp
+++ b/src/include/appstate.cpp
@@ -11,7 +11,8 @@ AppState* AppState::instance = nullptr;
 AppState::AppState() {
     pluginInitialized = false;
     debuggingEnabled = false;
-    fastUpdate = false;
+    updateSpeed = UpdateSpeed::SLOW;
+    hasActiveProfile = false;
 }
 
 AppState::~AppState() {
@@ -63,11 +64,17 @@ float AppState::Update(float inElapsedSinceLastCall, float inElapsedTimeSinceLas
     
     appstate->update();
     
-    if (!USBController::getInstance()->allProfilesReady()) {
-        return REFRESH_INTERVAL_SECONDS_SLOW;
+    // Return appropriate refresh rate based on updateSpeed
+    switch (appstate->updateSpeed) {
+        case UpdateSpeed::SLOW:
+            return REFRESH_INTERVAL_SECONDS_SLOW;     // 5.0s - No profile loaded
+        case UpdateSpeed::NORMAL:
+            return REFRESH_INTERVAL_SECONDS_NORMAL;   // 0.4s - Aircraft in the air
+        case UpdateSpeed::FAST:
+            return REFRESH_INTERVAL_SECONDS_FAST;     // 0.1s - Wheels on ground
+        default:
+            return REFRESH_INTERVAL_SECONDS_NORMAL;
     }
-    
-    return appstate->fastUpdate ? REFRESH_INTERVAL_SECONDS_FAST : REFRESH_INTERVAL_SECONDS_NORMAL;
 }
 
 void AppState::update() {

--- a/src/include/appstate.h
+++ b/src/include/appstate.h
@@ -12,6 +12,12 @@ struct DelayedTask {
     std::function<void()> func;
 };
 
+enum class UpdateSpeed {
+    SLOW,    // 5.0s - No profile loaded
+    NORMAL,  // 0.4s - Aircraft in the air
+    FAST     // 0.1s - Wheels on ground
+};
+
 class AppState {
 private:
     AppState();
@@ -25,8 +31,9 @@ public:
     static float Update(float inElapsedSinceLastCall, float inElapsedTimeSinceLastFlightLoop, int inCounter, void *inRefcon);
     
     bool pluginInitialized;
-    bool fastUpdate;
+    UpdateSpeed updateSpeed;
     bool debuggingEnabled;
+    bool hasActiveProfile;
     
     static AppState* getInstance();
     bool initialize();

--- a/src/include/products/fcu-efis/product-fcu-efis.cpp
+++ b/src/include/products/fcu-efis/product-fcu-efis.cpp
@@ -92,6 +92,9 @@ void ProductFCUEfis::setProfileForCurrentAircraft() {
         profile = new TolissFCUEfisProfile(this);
         monitorDatarefs();
         profileReady = true;
+        // Profile loaded, set update speed to NORMAL
+        AppState::getInstance()->hasActiveProfile = true;
+        AppState::getInstance()->updateSpeed = UpdateSpeed::NORMAL;
     }
     else {
         debug("No eligible profiles found for %s. Has the aircraft finished loading?\n", classIdentifier());

--- a/src/include/products/fcu-efis/profiles/toliss-fcu-efis-profile.cpp
+++ b/src/include/products/fcu-efis/profiles/toliss-fcu-efis-profile.cpp
@@ -1,6 +1,7 @@
 #include "toliss-fcu-efis-profile.h"
 #include "product-fcu-efis.h"
 #include "dataref.h"
+#include "appstate.h"
 #include <cstring>
 #include <algorithm>
 #include <sstream>

--- a/src/include/products/mcdu/product-mcdu.cpp
+++ b/src/include/products/mcdu/product-mcdu.cpp
@@ -1,14 +1,17 @@
 #include "product-mcdu.h"
 #include "dataref.h"
 #include "appstate.h"
+#include "config.h"
 #include "toliss-mcdu-profile.h"
 #include "laminar-mcdu-profile.h"
+#include <chrono>
 
 ProductMCDU::ProductMCDU(HIDDeviceHandle hidDevice, uint16_t vendorId, uint16_t productId, std::string vendorName, std::string productName) : USBDevice(hidDevice, vendorId, productId, vendorName, productName) {
     profile = nullptr;
     page = std::vector<std::vector<char>>(ProductMCDU::PageLines, std::vector<char>(ProductMCDU::PageBytesPerLine, ' '));
     previousPage = std::vector<std::vector<char>>(ProductMCDU::PageLines, std::vector<char>(ProductMCDU::PageBytesPerLine, ' '));
     pressedButtonIndices = {};
+    lastDisplayUpdate = std::chrono::steady_clock::now();
     
     connect();
 }
@@ -19,21 +22,33 @@ ProductMCDU::~ProductMCDU() {
 
 void ProductMCDU::setProfileForCurrentAircraft() {
     if (TolissMcduProfile::IsEligible()) {
-        debug("Using Toliss profile for %s.\n", classIdentifier());
+        debug("MCDU: Using Toliss profile for %s.\n", classIdentifier());
         clear();
         profile = new TolissMcduProfile(this);
         monitorDatarefs();
         profileReady = true;
+        // Profile loaded, set update speed to NORMAL
+        AppState::getInstance()->hasActiveProfile = true;
+        AppState::getInstance()->updateSpeed = UpdateSpeed::NORMAL;
     }
     else if (LaminarMcduProfile::IsEligible()) {
-        debug("Using Laminar profile for %s.\n", classIdentifier());
+        debug("MCDU: Using Laminar profile for %s.\n", classIdentifier());
         clear();
         profile = new LaminarMcduProfile(this);
         monitorDatarefs();
         profileReady = true;
+        // Profile loaded, set update speed to NORMAL
+        AppState::getInstance()->hasActiveProfile = true;
+        AppState::getInstance()->updateSpeed = UpdateSpeed::NORMAL;
     }
     else {
-        debug("No eligible profiles found for %s. Has the aircraft finished loading?\n", classIdentifier());
+        static int profileCheckCount = 0;
+        profileCheckCount++;
+        // Log every 50 checks
+        if (profileCheckCount % 50 == 1) {
+            debug("MCDU: No eligible profiles found for %s. Has the aircraft finished loading?\n",
+                       classIdentifier());
+        }
         setLedBrightness(MCDULed::FAIL, 1);
     }
 }
@@ -136,11 +151,23 @@ void ProductMCDU::update() {
         return;
     }
     
+    // Always process button inputs immediately
     USBDevice::update();
-    updatePage();
+    
+    // Throttle display updates to reduce blocking
+    auto now = std::chrono::steady_clock::now();
+    auto timeSinceLastUpdate = std::chrono::duration_cast<std::chrono::milliseconds>(now - lastDisplayUpdate).count();
+    
+    if (timeSinceLastUpdate >= DISPLAY_UPDATE_INTERVAL_MS) {
+        updatePage();
+        lastDisplayUpdate = now;
+    }
 }
 
 void ProductMCDU::didReceiveData(int reportId, uint8_t *report, int reportLength) {
+    static uint64_t lastButtonState_lo = 0;
+    static uint32_t lastButtonState_hi = 0;
+    
     if (!connected || !profile || !report || reportLength <= 0) {
         return;
     }
@@ -166,6 +193,14 @@ void ProductMCDU::didReceiveData(int reportId, uint8_t *report, int reportLength
         buttons_hi |= ((uint32_t)report[i+9]) << (8 * i);
     }
     
+    // Skip processing if button state hasn't changed
+    if (buttons_lo == lastButtonState_lo && buttons_hi == lastButtonState_hi) {
+        return; // No button state change, don't waste CPU cycles
+    }
+    
+    lastButtonState_lo = buttons_lo;
+    lastButtonState_hi = buttons_hi;
+    
     const std::vector<MCDUButtonDef>& currentButtonDefs = profile->buttonDefs();
     size_t numButtons = currentButtonDefs.size();
     
@@ -182,9 +217,8 @@ void ProductMCDU::didReceiveData(int reportId, uint8_t *report, int reportLength
             pressedButtonIndices.insert(i);
             profile->buttonPressed(&currentButtonDefs[i], xplm_CommandBegin);
         }
-        else if (pressed && pressedButtonIndexExists) {
-            profile->buttonPressed(&currentButtonDefs[i], xplm_CommandContinue);
-        }
+        // Skip CommandContinue calls to prevent flooding X-Plane with continuous commands
+        // MCDU buttons are typically single-action, not continuous-action
         else if (!pressed && pressedButtonIndexExists) {
             pressedButtonIndices.erase(i);
             profile->buttonPressed(&currentButtonDefs[i], xplm_CommandEnd);

--- a/src/include/products/mcdu/product-mcdu.h
+++ b/src/include/products/mcdu/product-mcdu.h
@@ -5,6 +5,7 @@
 #include "mcdu-aircraft-profile.h"
 #include <map>
 #include <set>
+#include <chrono>
 
 class ProductMCDU: public USBDevice {
 private:
@@ -13,6 +14,10 @@ private:
     std::vector<std::vector<char>> previousPage;
     std::map<std::string, std::string> cachedDatarefValues;
     std::set<int> pressedButtonIndices;
+    
+    // Display update throttling
+    std::chrono::steady_clock::time_point lastDisplayUpdate;
+    static constexpr int DISPLAY_UPDATE_INTERVAL_MS = 50; // 20 FPS max for display
     
     void updatePage();
     void draw(const std::vector<std::vector<char>> *pagePtr = nullptr);

--- a/src/include/products/mcdu/profiles/toliss-mcdu-profile.cpp
+++ b/src/include/products/mcdu/profiles/toliss-mcdu-profile.cpp
@@ -1,6 +1,7 @@
 #include "toliss-mcdu-profile.h"
 #include "product-mcdu.h"
 #include "dataref.h"
+#include "config.h"
 #include <algorithm>
 
 TolissMcduProfile::TolissMcduProfile(ProductMCDU *product) : McduAircraftProfile(product) {

--- a/src/include/products/pfp/product-pfp.cpp
+++ b/src/include/products/pfp/product-pfp.cpp
@@ -28,6 +28,9 @@ void ProductPFP::setProfileForCurrentAircraft() {
         profile = new ZiboPfpProfile(this);
         monitorDatarefs();
         profileReady = true;
+        // Profile loaded, set update speed to NORMAL
+        AppState::getInstance()->hasActiveProfile = true;
+        AppState::getInstance()->updateSpeed = UpdateSpeed::NORMAL;
     }
     else if (FlightFactor777PfpProfile::IsEligible()) {
         debug("Using FlightFactor 777 PFP profile for %s.\n", classIdentifier());
@@ -35,6 +38,9 @@ void ProductPFP::setProfileForCurrentAircraft() {
         profile = new FlightFactor777PfpProfile(this);
         monitorDatarefs();
         profileReady = true;
+        // Profile loaded, set update speed to NORMAL
+        AppState::getInstance()->hasActiveProfile = true;
+        AppState::getInstance()->updateSpeed = UpdateSpeed::NORMAL;
     }
     else if (SSG748PfpProfile::IsEligible()) {
         debug("Using SSG 748 PFP profile for %s.\n", classIdentifier());
@@ -42,6 +48,9 @@ void ProductPFP::setProfileForCurrentAircraft() {
         profile = new SSG748PfpProfile(this);
         monitorDatarefs();
         profileReady = true;
+        // Profile loaded, set update speed to NORMAL
+        AppState::getInstance()->hasActiveProfile = true;
+        AppState::getInstance()->updateSpeed = UpdateSpeed::NORMAL;
     }
     else {
         debug("No eligible profiles found for %s. Has the aircraft finished loading?\n", classIdentifier());

--- a/src/include/products/ursa-minor-joystick/product-ursa-minor-joystick.cpp
+++ b/src/include/products/ursa-minor-joystick/product-ursa-minor-joystick.cpp
@@ -36,7 +36,10 @@ void ProductUrsaMinorJoystick::disconnect() {
     Dataref::getInstance()->unbind("AirbusFBW/PanelBrightnessLevel");
     Dataref::getInstance()->unbind("sim/flightmodel/failures/onground_any");
     didInitializeDatarefs = false;
-    AppState::getInstance()->fastUpdate = false;
+    // Reset update speed when disconnecting
+    if (AppState::getInstance()->hasActiveProfile) {
+        AppState::getInstance()->updateSpeed = UpdateSpeed::NORMAL;
+    }
 }
 
 void ProductUrsaMinorJoystick::update() {
@@ -109,7 +112,10 @@ void ProductUrsaMinorJoystick::initializeDatarefs() {
     });
     
     Dataref::getInstance()->monitorExistingDataref<bool>("sim/flightmodel/failures/onground_any", [this](bool wheelsOnGround) {
-        AppState::getInstance()->fastUpdate = wheelsOnGround;
+        // Set update speed based on wheels on ground status
+        if (AppState::getInstance()->hasActiveProfile) {
+            AppState::getInstance()->updateSpeed = wheelsOnGround ? UpdateSpeed::FAST : UpdateSpeed::NORMAL;
+        }
         
         if (!wheelsOnGround && lastVibration > 0) {
             lastVibration = 0;


### PR DESCRIPTION
Adds support for three different update speeds depending on airplane state (profile not loaded, airplane on ground, airplane in the air) to speed up MCDU while not being on the ground
