### PR TITLE
add missinig 777v2 datarefs

### DIFF
--- a/src/include/products/fmc/profiles/ff777-fmc-profile.cpp
+++ b/src/include/products/fmc/profiles/ff777-fmc-profile.cpp
@@ -13,14 +13,19 @@ FlightFactor777FMCProfile::FlightFactor777FMCProfile(ProductFMC *product) :
     product->setAllLedsEnabled(false);
     product->setFont(Font::GlyphData(FontVariant::Font737, product->identifierByte));
 
-    Dataref::getInstance()->monitorExistingDataref<float>("sim/cockpit/electrical/instrument_brightness", [product](float brightness) {
-        uint8_t target = Dataref::getInstance()->get<bool>("sim/cockpit/electrical/avionics_on") ? brightness * 255.0f : 0;
-        product->setLedBrightness(FMCLed::BACKLIGHT, target);
+    Dataref::getInstance()->monitorExistingDataref<float>("1-sim/cduL/brt", [product](float brightness) {
+        uint8_t target = Dataref::getInstance()->get<bool>("1-sim/cduL/ok") ? brightness * 255.0f : 0;
         product->setLedBrightness(FMCLed::SCREEN_BACKLIGHT, target);
     });
 
-    Dataref::getInstance()->monitorExistingDataref<bool>("sim/cockpit/electrical/avionics_on", [](bool poweredOn) {
-        Dataref::getInstance()->executeChangedCallbacksForDataref("sim/cockpit/electrical/instrument_brightness");
+    Dataref::getInstance()->monitorExistingDataref<float>("1-sim/ckpt/lights/aisle", [product](float brightness) {
+        uint8_t target = Dataref::getInstance()->get<bool>("1-sim/cduL/ok") ? brightness * 255.0f : 0;
+        product->setLedBrightness(FMCLed::BACKLIGHT, target);
+    });
+
+    Dataref::getInstance()->monitorExistingDataref<bool>("1-sim/cduL/ok", [](bool poweredOn) {
+        Dataref::getInstance()->executeChangedCallbacksForDataref("1-sim/cduL/brt");
+        Dataref::getInstance()->executeChangedCallbacksForDataref("1-sim/ckpt/lights/aisle");
     });
 
     Dataref::getInstance()->monitorExistingDataref<bool>("1-sim/ckpt/lamps/cduCptAct", [product](bool enabled) {
@@ -32,11 +37,19 @@ FlightFactor777FMCProfile::FlightFactor777FMCProfile(ProductFMC *product) :
         product->setLedBrightness(FMCLed::PFP_MSG, enabled ? 1 : 0);
         product->setLedBrightness(FMCLed::MCDU_RDY, enabled ? 1 : 0);
     });
+
+    Dataref::getInstance()->monitorExistingDataref<bool>("1-sim/ckpt/lamps/cduCptOFST", [product](bool enabled) {
+        product->setLedBrightness(FMCLed::PFP_OFST, enabled ? 1 : 0);
+    });
 }
 
 FlightFactor777FMCProfile::~FlightFactor777FMCProfile() {
-    Dataref::getInstance()->unbind("sim/cockpit/electrical/instrument_brightness");
-    Dataref::getInstance()->unbind("sim/cockpit/electrical/avionics_on");
+    Dataref::getInstance()->unbind("1-sim/cduL/brt");
+    Dataref::getInstance()->unbind("1-sim/ckpt/lights/aisle");
+    Dataref::getInstance()->unbind("1-sim/cduL/ok");
+    Dataref::getInstance()->unbind("1-sim/ckpt/lamps/cduCptAct");
+    Dataref::getInstance()->unbind("1-sim/ckpt/lamps/cduCptMSG");
+    Dataref::getInstance()->unbind("1-sim/ckpt/lamps/cduCptOFST");
 }
 
 bool FlightFactor777FMCProfile::IsEligible() {


### PR DESCRIPTION
In the latest version of the 777v2 some missing datarefs were added:
```
2.2.2
- made AT less aggressive on high alt
- added requested mcp datarefs:
    1-sim/output/mcp/ok int, does mcp work or not
    1-sim/output/mcp/isSpdOpen int
    1-sim/output/mcp/isVsOpen int
- added requested cdu datarefs:
    1-sim/cdu[L, R, C]/ok int, does cdu work or not
    1-sim/cdu[L, R, C]/brt float, actual display brt
- added backlit to the clocks
- added more useful options for afk pilots, consult the the manual for details
- corrections for rte data displaying on nd
```
I have added those new datarefs and also splitted **BACKLIGHT** from **SCREEN_BACKLIGHT**. I have also added missing **PFP_OFST** light.