### PR TITLE
fix: fix potential crash when a device is connected but no suitable profile exists

### DIFF
--- a/src/include/products/agp/product-agp.cpp
+++ b/src/include/products/agp/product-agp.cpp
@@ -275,6 +275,10 @@ void ProductAGP::didReceiveData(int reportId, uint8_t *report, int reportLength)
 void ProductAGP::didReceiveButton(uint16_t hardwareButtonIndex, bool pressed, uint8_t count) {
     USBDevice::didReceiveButton(hardwareButtonIndex, pressed, count);
 
+    if (!connected || !profile) {
+        return;
+    }
+
     auto &buttons = profile->buttonDefs();
     auto it = buttons.find(hardwareButtonIndex);
     if (it == buttons.end()) {

--- a/src/include/products/ecam/product-ecam.cpp
+++ b/src/include/products/ecam/product-ecam.cpp
@@ -133,6 +133,10 @@ void ProductECAM::didReceiveData(int reportId, uint8_t *report, int reportLength
 void ProductECAM::didReceiveButton(uint16_t hardwareButtonIndex, bool pressed, uint8_t count) {
     USBDevice::didReceiveButton(hardwareButtonIndex, pressed, count);
 
+    if (!connected || !profile) {
+        return;
+    }
+
     auto &buttons = profile->buttonDefs();
     auto it = buttons.find(hardwareButtonIndex);
     if (it == buttons.end()) {

--- a/src/include/products/tcas/product-tcas.cpp
+++ b/src/include/products/tcas/product-tcas.cpp
@@ -193,6 +193,10 @@ void ProductTCAS::didReceiveData(int reportId, uint8_t *report, int reportLength
 void ProductTCAS::didReceiveButton(uint16_t hardwareButtonIndex, bool pressed, uint8_t count) {
     USBDevice::didReceiveButton(hardwareButtonIndex, pressed, count);
 
+    if (!connected || !profile) {
+        return;
+    }
+
     auto &buttons = profile->buttonDefs();
     auto it = buttons.find(hardwareButtonIndex);
     if (it == buttons.end()) {


### PR DESCRIPTION
Reproducible with the FF 777v2 and the ECAM32 but can also be triggered with other configs. `didReceiveButton()` may be called with `profile` set to `nullptr`. This patch adds the same check to the latest products as the one that is performed for others.