### PR TITLE
Add CL650 and Q4XP FMC/FCU-EFIS support

### DIFF
--- a/src/include/products/fcu-efis/product-fcu-efis.cpp
+++ b/src/include/products/fcu-efis/product-fcu-efis.cpp
@@ -6,6 +6,8 @@
 #include "plugins-menu.h"
 #include "profiles/c172-fcu-efis-profile.h"
 #include "profiles/cis-seneca-fcu-efis-profile.h"
+#include "profiles/cl650-fcu-efis-profile.h"
+#include "profiles/q4xp-fcu-efis-profile.h"
 #include "profiles/ff350-fcu-efis-profile.h"
 #include "profiles/ff767-fcu-efis-profile.h"
 #include "profiles/ff777-fcu-efis-profile.h"
@@ -70,6 +72,12 @@ void ProductFCUEfis::setProfileForCurrentAircraft() {
         profileReady = true;
     } else if (XCraftsErjFCUEfisProfile::IsEligible()) {
         profile = new XCraftsErjFCUEfisProfile(this);
+        profileReady = true;
+    } else if (Q4XPFCUEfisProfile::IsEligible()) {
+        profile = new Q4XPFCUEfisProfile(this);
+        profileReady = true;
+    } else if (CL650FCUEfisProfile::IsEligible()) {
+        profile = new CL650FCUEfisProfile(this);
         profileReady = true;
     } else if (TolissFCUEfisProfile::IsEligible()) {
         profile = new TolissFCUEfisProfile(this);

--- a/src/include/products/fcu-efis/profiles/cl650-fcu-efis-profile.cpp
+++ b/src/include/products/fcu-efis/profiles/cl650-fcu-efis-profile.cpp
@@ -1,0 +1,112 @@
+#include "cl650-fcu-efis-profile.h"
+
+#include "dataref.h"
+#include "product-fcu-efis.h"
+
+#include <algorithm>
+#include <XPLMUtilities.h>
+
+CL650FCUEfisProfile::CL650FCUEfisProfile(ProductFCUEfis *product) : FCUEfisAircraftProfile(product) {
+    Dataref::getInstance()->monitorExistingDataref<float>("CL650/lamps/integ/P2LM_plt_glrshld", [product](float val) {
+        uint8_t target = static_cast<uint8_t>(std::clamp(val, 0.0f, 1.0f) * 255);
+        product->setLedBrightness(FCUEfisLed::BACKLIGHT, target);
+        product->setLedBrightness(FCUEfisLed::EXPED_BACKLIGHT, target);
+        product->setLedBrightness(FCUEfisLed::EFISR_BACKLIGHT, target);
+        product->setLedBrightness(FCUEfisLed::EFISL_BACKLIGHT, target);
+        product->forceStateSync();
+    });
+
+    Dataref::getInstance()->monitorExistingDataref<float>("CL650/lamps/glareshield/FCP/ap_eng_1", [product](float val) {
+        product->setLedBrightness(FCUEfisLed::AP1_GREEN, val > 0.5f ? 1 : 0);
+    });
+
+    Dataref::getInstance()->monitorExistingDataref<float>("CL650/lamps/glareshield/FCP/ap_eng_2", [product](float val) {
+        product->setLedBrightness(FCUEfisLed::AP2_GREEN, val > 0.5f ? 1 : 0);
+    });
+
+    Dataref::getInstance()->monitorExistingDataref<float>("CL650/lamps/glareshield/FCP/appr_1", [product](float val) {
+        product->setLedBrightness(FCUEfisLed::APPR_GREEN, val > 0.5f ? 1 : 0);
+    });
+
+    Dataref::getInstance()->monitorExistingDataref<float>("CL650/lamps/glareshield/ats_L", [product](float val) {
+        product->setLedBrightness(FCUEfisLed::ATHR_GREEN, val > 0.5f ? 1 : 0);
+    });
+}
+
+CL650FCUEfisProfile::~CL650FCUEfisProfile() {
+    Dataref::getInstance()->unbind("CL650/lamps/integ/P2LM_plt_glrshld");
+    Dataref::getInstance()->unbind("CL650/lamps/glareshield/FCP/ap_eng_1");
+    Dataref::getInstance()->unbind("CL650/lamps/glareshield/FCP/ap_eng_2");
+    Dataref::getInstance()->unbind("CL650/lamps/glareshield/FCP/appr_1");
+    Dataref::getInstance()->unbind("CL650/lamps/glareshield/ats_L");
+}
+
+bool CL650FCUEfisProfile::IsEligible() {
+    return Dataref::getInstance()->exists("CL650/CDU/1/screen/text_line0");
+}
+
+const std::vector<std::string> &CL650FCUEfisProfile::displayDatarefs() const {
+    static const std::vector<std::string> datarefs = {};
+    return datarefs;
+}
+
+const std::unordered_map<uint16_t, FCUEfisButtonDef> &CL650FCUEfisProfile::buttonDefs() const {
+    static const std::unordered_map<uint16_t, FCUEfisButtonDef> buttons = {
+        // FCU main panel
+        {0,  {"SPD/MACH", "CL650/FCP/ias_mach"}},
+        {3,  {"AP1",   "CL650/FCP/ap_eng"}},
+        {4,  {"AP2",   "CL650/FCP/ap_eng"}},
+        {5,  {"A/THR", "CL650/glareshield/ATS"}},
+        {8,  {"APPR",  "CL650/FCP/appr_mode"}},
+
+        // Speed encoder
+        {9,  {"SPD DEC", "CL650/FCP/speed_down"}},
+        {10, {"SPD INC", "CL650/FCP/speed_up"}},
+
+        // Heading encoder
+        {13, {"HDG DEC",  "CL650/FCP/hdg_down"}},
+        {14, {"HDG INC",  "CL650/FCP/hdg_up"}},
+        {15, {"HDG PUSH", "CL650/FCP/hdg_mode"}},
+        {16, {"HDG PULL", "CL650/FCP/hdy_sync"}},
+
+        // Altitude encoder
+        {17, {"ALT DEC",  "CL650/FCP/alt_down"}},
+        {18, {"ALT INC",  "CL650/FCP/alt_up"}},
+        {19, {"ALT PUSH", "CL650/FCP/vnav_mode"}},
+        {20, {"ALT PULL", "CL650/FCP/alt_mode"}},
+
+        // Vertical Speed encoder
+        {21, {"VS DEC",  "CL650/FCP/vs_pitch_down"}},
+        {22, {"VS INC",  "CL650/FCP/vs_pitch_up"}},
+        {23, {"VS PUSH", "CL650/FCP/vs_mode"}},
+
+        // EFIS Left — FD + Baro
+        {32, {"L_FD", "CL650/FCP/fd1"}},
+        {39, {"L_BARO PUSH", "CL650/DCP/1/baro_push"}},
+        {41, {"L_BARO DEC",  "CL650/DCP/1/baro_down"}},
+        {42, {"L_BARO INC",  "CL650/DCP/1/baro_up"}},
+
+        // EFIS Right — FD + Baro
+        {64, {"R_FD", "CL650/FCP/fd2"}},
+        {71, {"R_BARO PUSH", "CL650/DCP/2/baro_push"}},
+        {73, {"R_BARO DEC",  "CL650/DCP/2/baro_down"}},
+        {74, {"R_BARO INC",  "CL650/DCP/2/baro_up"}},
+    };
+
+    return buttons;
+}
+
+void CL650FCUEfisProfile::updateDisplayData(FCUDisplayData &data) {
+    data.displayEnabled = false;
+}
+
+void CL650FCUEfisProfile::buttonPressed(const FCUEfisButtonDef *button, XPLMCommandPhase phase) {
+    if (!button || button->dataref.empty() || phase == xplm_CommandContinue) {
+        return;
+    }
+
+    auto datarefManager = Dataref::getInstance();
+    if (phase == xplm_CommandBegin) {
+        datarefManager->executeCommand(button->dataref.c_str());
+    }
+}

--- a/src/include/products/fcu-efis/profiles/cl650-fcu-efis-profile.h
+++ b/src/include/products/fcu-efis/profiles/cl650-fcu-efis-profile.h
@@ -1,0 +1,32 @@
+#ifndef CL650_FCU_EFIS_PROFILE_H
+#define CL650_FCU_EFIS_PROFILE_H
+
+#include "fcu-efis-aircraft-profile.h"
+
+#include <map>
+#include <string>
+#include <unordered_map>
+
+class CL650FCUEfisProfile : public FCUEfisAircraftProfile {
+    public:
+        CL650FCUEfisProfile(ProductFCUEfis *product);
+        ~CL650FCUEfisProfile();
+
+        static bool IsEligible();
+
+        const std::vector<std::string> &displayDatarefs() const override;
+        const std::unordered_map<uint16_t, FCUEfisButtonDef> &buttonDefs() const override;
+        void updateDisplayData(FCUDisplayData &data) override;
+
+        bool hasEfisLeft() const override {
+            return true;
+        }
+
+        bool hasEfisRight() const override {
+            return true;
+        }
+
+        void buttonPressed(const FCUEfisButtonDef *button, XPLMCommandPhase phase) override;
+};
+
+#endif

--- a/src/include/products/fcu-efis/profiles/q4xp-fcu-efis-profile.cpp
+++ b/src/include/products/fcu-efis/profiles/q4xp-fcu-efis-profile.cpp
@@ -1,0 +1,178 @@
+#include "q4xp-fcu-efis-profile.h"
+
+#include "dataref.h"
+#include "product-fcu-efis.h"
+
+#include <algorithm>
+#include <cmath>
+#include <iomanip>
+#include <sstream>
+#include <XPLMUtilities.h>
+
+Q4XPFCUEfisProfile::Q4XPFCUEfisProfile(ProductFCUEfis *product) : FCUEfisAircraftProfile(product) {
+    Dataref::getInstance()->monitorExistingDataref<std::vector<float>>("FJS/Q4XP/Lights/panelText_LIT", [product](const std::vector<float> &brightness) {
+        if (brightness.size() <= 1) {
+            return;
+        }
+
+        uint8_t target = static_cast<uint8_t>(std::clamp(brightness[1], 0.0f, 1.0f) * 255);
+        product->setLedBrightness(FCUEfisLed::BACKLIGHT, target);
+        product->setLedBrightness(FCUEfisLed::EXPED_BACKLIGHT, target);
+        product->setLedBrightness(FCUEfisLed::EFISL_BACKLIGHT, target);
+        product->setLedBrightness(FCUEfisLed::EFISR_BACKLIGHT, target);
+        product->forceStateSync();
+    },
+        this);
+
+    product->setLedBrightness(FCUEfisLed::SCREEN_BACKLIGHT, 128);
+    product->setLedBrightness(FCUEfisLed::EFISL_SCREEN_BACKLIGHT, 128);
+    product->setLedBrightness(FCUEfisLed::EFISR_SCREEN_BACKLIGHT, 128);
+    product->setLedBrightness(FCUEfisLed::OVERALL_GREEN, 255);
+    product->setLedBrightness(FCUEfisLed::EFISL_OVERALL_GREEN, 255);
+    product->setLedBrightness(FCUEfisLed::EFISR_OVERALL_GREEN, 255);
+    product->forceStateSync();
+}
+
+Q4XPFCUEfisProfile::~Q4XPFCUEfisProfile() {
+}
+
+bool Q4XPFCUEfisProfile::IsEligible() {
+    return Dataref::getInstance()->exists("FJS/Q4XP/cdu1/text_line_0");
+}
+
+const std::vector<std::string> &Q4XPFCUEfisProfile::displayDatarefs() const {
+    static const std::vector<std::string> datarefs = {
+        "sim/cockpit/autopilot/airspeed",
+        "sim/cockpit/autopilot/heading_mag",
+        "sim/cockpit/autopilot/altitude",
+        "sim/cockpit/autopilot/vertical_velocity",
+        "sim/cockpit/misc/barometer_setting",
+        "sim/cockpit/misc/barometer_setting2",
+    };
+    return datarefs;
+}
+
+const std::unordered_map<uint16_t, FCUEfisButtonDef> &Q4XPFCUEfisProfile::buttonDefs() const {
+    static const std::unordered_map<uint16_t, FCUEfisButtonDef> buttons = {
+        // FCU buttons
+        {3,  {"AP1",  "FJS/Q4XP/Autopilot/FGCP_BUTTON_AP"}},
+        {4,  {"AP2",  "FJS/Q4XP/Autopilot/FGCP_BUTTON_AP"}},
+        {7,  {"METRIC", "FJS/Q4XP/Switches/PFDALTUNITS"}},
+
+        // Speed encoder
+        {9,  {"SPD DEC",  "sim/autopilot/airspeed_down"}},
+        {10, {"SPD INC",  "sim/autopilot/airspeed_up"}},
+        {11, {"SPD PUSH", "sim/autopilot/airspeed_sync"}},
+        {12, {"SPD PULL", "sim/autopilot/airspeed_sync"}},
+
+        // Heading encoder
+        {13, {"HDG DEC",  "sim/autopilot/heading_down"}},
+        {14, {"HDG INC",  "sim/autopilot/heading_up"}},
+        {15, {"HDG PUSH", "sim/autopilot/heading"}},
+        {16, {"HDG PULL", "sim/autopilot/heading_sync"}},
+
+        // Altitude encoder
+        {17, {"ALT DEC",  "sim/autopilot/altitude_down"}},
+        {18, {"ALT INC",  "sim/autopilot/altitude_up"}},
+        {19, {"ALT PUSH", "sim/autopilot/altitude_arm"}},
+        {20, {"ALT PULL", "sim/autopilot/altitude_arm"}},
+
+        // Vertical Speed encoder
+        {21, {"VS DEC",  "sim/autopilot/vertical_speed_down"}},
+        {22, {"VS INC",  "sim/autopilot/vertical_speed_up"}},
+        {23, {"VS PUSH", "sim/autopilot/vertical_speed_sync"}},
+        {24, {"VS PULL", "sim/autopilot/vertical_speed_sync"}},
+
+        // EFIS Left — Baro
+        {39, {"L_STD PUSH", "sim/instruments/barometer_std"}},
+        {40, {"L_STD PULL", "sim/instruments/barometer_std"}},
+        {41, {"L_BARO DEC", "sim/instruments/barometer_down"}},
+        {42, {"L_BARO INC", "sim/instruments/barometer_up"}},
+
+        // EFIS Right — Baro
+        {71, {"R_STD PUSH", "sim/instruments/barometer_copilot_std"}},
+        {72, {"R_STD PULL", "sim/instruments/barometer_copilot_std"}},
+        {73, {"R_BARO DEC", "sim/instruments/barometer_copilot_down"}},
+        {74, {"R_BARO INC", "sim/instruments/barometer_copilot_up"}},
+    };
+
+    return buttons;
+}
+
+void Q4XPFCUEfisProfile::updateDisplayData(FCUDisplayData &data) {
+    auto dm = Dataref::getInstance();
+
+    data.displayEnabled = true;
+
+    // Speed
+    float ias = dm->getCached<float>("sim/cockpit/autopilot/airspeed");
+    {
+        std::ostringstream oss;
+        oss << std::setw(3) << std::setfill('0') << static_cast<int>(std::round(ias));
+        data.speed = oss.str();
+    }
+    data.spdMach = false;
+    data.spdManaged = false;
+
+    // Heading
+    float hdg = dm->getCached<float>("sim/cockpit/autopilot/heading_mag");
+    {
+        int hdgInt = static_cast<int>(std::round(hdg)) % 360;
+        std::ostringstream oss;
+        oss << std::setw(3) << std::setfill('0') << hdgInt;
+        data.heading = oss.str();
+    }
+    data.headingHdg = true;
+    data.headingTrk = false;
+    data.headingLat = false;
+    data.hdgManaged = false;
+
+    // Altitude
+    float alt = dm->getCached<float>("sim/cockpit/autopilot/altitude");
+    {
+        std::ostringstream oss;
+        oss << std::setw(5) << std::setfill('0') << static_cast<int>(std::round(alt));
+        data.altitude = oss.str();
+    }
+    data.altManaged = false;
+    data.altIndication = true;
+    data.lvlChange = false;
+
+    // Vertical Speed
+    float vs = dm->getCached<float>("sim/cockpit/autopilot/vertical_velocity");
+    {
+        bool negative = vs < 0;
+        int vsAbs = static_cast<int>(std::round(std::abs(vs)));
+        std::ostringstream oss;
+        oss << std::setw(4) << std::setfill('0') << vsAbs;
+        data.verticalSpeed = oss.str();
+        data.vsSign = negative;
+    }
+    data.vsMode = true;
+    data.fpaMode = false;
+    data.vsIndication = true;
+    data.vsHorizontalLine = false;
+    data.vsVerticalLine = false;
+
+    // EFIS Baro — inHg → convert to hPa/mbar display
+    float baro1 = dm->getCached<float>("sim/cockpit/misc/barometer_setting");
+    data.efisLeft.displayEnabled = true;
+    data.efisLeft.unitIsInHg = false;
+    data.efisLeft.setBaro(baro1, false);
+
+    float baro2 = dm->getCached<float>("sim/cockpit/misc/barometer_setting2");
+    data.efisRight.displayEnabled = true;
+    data.efisRight.unitIsInHg = false;
+    data.efisRight.setBaro(baro2, false);
+}
+
+void Q4XPFCUEfisProfile::buttonPressed(const FCUEfisButtonDef *button, XPLMCommandPhase phase) {
+    if (!button || button->dataref.empty() || phase == xplm_CommandContinue) {
+        return;
+    }
+
+    auto datarefManager = Dataref::getInstance();
+    if (phase == xplm_CommandBegin) {
+        datarefManager->executeCommand(button->dataref.c_str());
+    }
+}

--- a/src/include/products/fcu-efis/profiles/q4xp-fcu-efis-profile.h
+++ b/src/include/products/fcu-efis/profiles/q4xp-fcu-efis-profile.h
@@ -1,0 +1,32 @@
+#ifndef Q4XP_FCU_EFIS_PROFILE_H
+#define Q4XP_FCU_EFIS_PROFILE_H
+
+#include "fcu-efis-aircraft-profile.h"
+
+#include <map>
+#include <string>
+#include <unordered_map>
+
+class Q4XPFCUEfisProfile : public FCUEfisAircraftProfile {
+    public:
+        Q4XPFCUEfisProfile(ProductFCUEfis *product);
+        ~Q4XPFCUEfisProfile();
+
+        static bool IsEligible();
+
+        const std::vector<std::string> &displayDatarefs() const override;
+        const std::unordered_map<uint16_t, FCUEfisButtonDef> &buttonDefs() const override;
+        void updateDisplayData(FCUDisplayData &data) override;
+
+        bool hasEfisLeft() const override {
+            return true;
+        }
+
+        bool hasEfisRight() const override {
+            return true;
+        }
+
+        void buttonPressed(const FCUEfisButtonDef *button, XPLMCommandPhase phase) override;
+};
+
+#endif

--- a/src/include/products/fmc/product-fmc.cpp
+++ b/src/include/products/fmc/product-fmc.cpp
@@ -11,9 +11,11 @@
 #include "profiles/jar330-fmc-profile.h"
 #include "profiles/laminar-a333-fmc-profile.h"
 #include "profiles/laminar-citx-fmc-profile.h"
+#include "profiles/q4xp-fmc-profile.h"
 #include "profiles/rotatemd11-fmc-profile.h"
 #include "profiles/sparky744-fmc-profile.h"
 #include "profiles/stratosphere77w-fmc-profile.h"
+#include "profiles/cl650-fmc-profile.h"
 #include "profiles/toliss-fmc-profile.h"
 #include "profiles/xcrafts-ejets-fmc-profile.h"
 #include "profiles/xcrafts-erj-fmc-profile.h"
@@ -73,6 +75,14 @@ void ProductFMC::setProfileForCurrentAircraft() {
     } else if (TolissFMCProfile::IsEligible()) {
         clearDisplay();
         profile = new TolissFMCProfile(this);
+        profileReady = true;
+    } else if (CL650FMCProfile::IsEligible()) {
+        clearDisplay();
+        profile = new CL650FMCProfile(this);
+        profileReady = true;
+    } else if (Q4XPFMCProfile::IsEligible()) {
+        clearDisplay();
+        profile = new Q4XPFMCProfile(this);
         profileReady = true;
     } else if (LaminarA333FMCProfile::IsEligible()) {
         clearDisplay();

--- a/src/include/products/fmc/profiles/cl650-fmc-profile.cpp
+++ b/src/include/products/fmc/profiles/cl650-fmc-profile.cpp
@@ -1,0 +1,451 @@
+#include "cl650-fmc-profile.h"
+
+#include "config.h"
+#include "dataref.h"
+#include "product-fmc.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <iomanip>
+#include <sstream>
+
+CL650FMCProfile::CL650FMCProfile(ProductFMC *product) : FMCAircraftProfile(product) {
+    product->setAllLedsEnabled(false);
+
+    auto font = Font::GlyphData("CL650.xpwwf", product->identifierByte, product->hardwareType);
+    if (!font.empty()) {
+        for (auto &packet : font) {
+            product->writeData(packet);
+        }
+    } else {
+        product->setFont(FontVariant::FontAirbus);
+    }
+
+    const std::string cdu = product->deviceVariant == FMCDeviceVariant::VARIANT_CAPTAIN ? "1" : "2";
+    const std::string screenBrtRef = "CL650/CDU/" + cdu + "/screen/brt";
+    const std::string brtRef = "CL650/lamps/integ/1A1FS_cdu" + cdu;
+
+    Dataref::getInstance()->monitorExistingDataref<float>(screenBrtRef.c_str(), [product](float val) {
+        product->setLedBrightness(FMCLed::SCREEN_BACKLIGHT, static_cast<uint8_t>(std::clamp(val, 0.0f, 1.0f) * 255));
+    });
+
+    Dataref::getInstance()->monitorExistingDataref<float>(brtRef.c_str(), [product](float val) {
+        product->setLedBrightness(FMCLed::BACKLIGHT, static_cast<uint8_t>(std::clamp(val, 0.0f, 1.0f) * 255));
+    });
+
+#ifdef DEBUG
+    Dataref::getInstance()->createCommand(
+        PRODUCT_NAME "/debug/cl650_dump_styles", "Dump CL650 style_line values to log", [this](XPLMCommandPhase inPhase) {
+            if (inPhase != xplm_CommandBegin) {
+                return;
+            }
+
+            auto datarefManager = Dataref::getInstance();
+            const std::string cdu = product->deviceVariant == FMCDeviceVariant::VARIANT_CAPTAIN ? "1" : "2";
+
+            Logger::getInstance()->info("=== CL650 CDU style_line dump (CDU %s) ===\n", cdu.c_str());
+
+            for (int i = 0; i < 15; ++i) {
+                std::string styleDataref = "CL650/CDU/" + cdu + "/screen/style_line" + std::to_string(i);
+                std::string textDataref = "CL650/CDU/" + cdu + "/screen/text_line" + std::to_string(i);
+
+                std::vector<unsigned char> styleBytes = datarefManager->get<std::vector<unsigned char>>(styleDataref.c_str());
+                std::string text = datarefManager->get<std::string>(textDataref.c_str());
+
+                // Take first non-space char as reference
+                char sample = ' ';
+                for (char c : text) {
+                    if (c != ' ' && c != '\0') { sample = c; break; }
+                }
+
+                std::stringstream hexStyles;
+                hexStyles << std::hex << std::setfill('0');
+                for (int j = 0; j < 24 && j < styleBytes.size(); ++j) {
+                    if (j > 0) hexStyles << " ";
+                    hexStyles << std::setw(2) << (int)styleBytes[j];
+                }
+
+                Logger::getInstance()->info("  line%02d sample='%c' styles=[%s]\n", i, sample, hexStyles.str().c_str());
+            }
+
+            Logger::getInstance()->info("=== End CL650 style_line dump ===\n");
+        });
+#endif
+}
+
+CL650FMCProfile::~CL650FMCProfile() {
+    const std::string cdu = product->deviceVariant == FMCDeviceVariant::VARIANT_CAPTAIN ? "1" : "2";
+    Dataref::getInstance()->unbind(("CL650/CDU/" + cdu + "/screen/brt").c_str());
+    Dataref::getInstance()->unbind(("CL650/lamps/integ/1A1FS_cdu" + cdu).c_str());
+}
+
+bool CL650FMCProfile::IsEligible() {
+    return Dataref::getInstance()->exists("CL650/CDU/1/screen/text_line0");
+}
+
+const std::vector<std::string> &CL650FMCProfile::displayDatarefs() const {
+    static std::unordered_map<FMCDeviceVariant, std::vector<std::string>> cache;
+
+    auto it = cache.find(product->deviceVariant);
+    if (it == cache.end()) {
+        const std::string cdu = product->deviceVariant == FMCDeviceVariant::VARIANT_CAPTAIN ? "1" : "2";
+        std::vector<std::string> refs;
+        refs.push_back("CL650/CDU/" + cdu + "/screen/brt");
+        static constexpr int ScreenLines = 15;
+        for (int i = 0; i < ScreenLines; ++i) {
+            refs.push_back("CL650/CDU/" + cdu + "/screen/text_line" + std::to_string(i));
+            refs.push_back("CL650/CDU/" + cdu + "/screen/style_line" + std::to_string(i));
+        }
+        it = cache.emplace(product->deviceVariant, std::move(refs)).first;
+    }
+    return it->second;
+}
+
+const std::vector<FMCButtonDef> &CL650FMCProfile::buttonDefs() const {
+    static std::unordered_map<FMCDeviceVariant, std::vector<FMCButtonDef>> cache;
+
+    auto it = cache.find(product->deviceVariant);
+    if (it == cache.end()) {
+        const std::string cdu = product->deviceVariant == FMCDeviceVariant::VARIANT_CAPTAIN ? "1" : "2";
+
+        std::vector<FMCButtonDef> buttons = {
+            {FMCKey::LSK1L, "CL650/CDU/" + cdu + "/lsk_l1", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::LSK2L, "CL650/CDU/" + cdu + "/lsk_l2", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::LSK3L, "CL650/CDU/" + cdu + "/lsk_l3", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::LSK4L, "CL650/CDU/" + cdu + "/lsk_l4", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::LSK5L, "CL650/CDU/" + cdu + "/lsk_l5", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::LSK6L, "CL650/CDU/" + cdu + "/lsk_l6", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::LSK1R, "CL650/CDU/" + cdu + "/lsk_r1", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::LSK2R, "CL650/CDU/" + cdu + "/lsk_r2", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::LSK3R, "CL650/CDU/" + cdu + "/lsk_r3", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::LSK4R, "CL650/CDU/" + cdu + "/lsk_r4", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::LSK5R, "CL650/CDU/" + cdu + "/lsk_r5", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::LSK6R, "CL650/CDU/" + cdu + "/lsk_r6", FMCDatarefType::SET_VALUE, 1.0},
+
+            {FMCKey::MCDU_DIR, "CL650/CDU/" + cdu + "/dir", FMCDatarefType::SET_VALUE, 1.0},
+            {std::vector<FMCKey>{FMCKey::PFP_INIT_REF, FMCKey::MCDU_INIT}, "CL650/CDU/" + cdu + "/idx", FMCDatarefType::SET_VALUE, 1.0},
+            {std::vector<FMCKey>{FMCKey::MCDU_PERF, FMCKey::PFP3_N1_LIMIT}, "CL650/CDU/" + cdu + "/perf", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::MCDU_DATA, "CL650/CDU/" + cdu + "/mfd_data", FMCDatarefType::SET_VALUE, 1.0},
+            {std::vector<FMCKey>{FMCKey::MCDU_SEC_FPLN, FMCKey::PFP_ROUTE}, "CL650/CDU/" + cdu + "/fpln", FMCDatarefType::SET_VALUE, 1.0},
+            {std::vector<FMCKey>{FMCKey::MCDU_RAD_NAV, FMCKey::PFP4_NAV_RAD, FMCKey::PFP7_NAV_RAD}, "CL650/CDU/" + cdu + "/tun", FMCDatarefType::SET_VALUE, 1.0},
+            {std::vector<FMCKey>{FMCKey::PFP_LEGS, FMCKey::MCDU_FPLN}, "CL650/CDU/" + cdu + "/legs", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::PFP_DEP_ARR, "CL650/CDU/" + cdu + "/dep_arr", FMCDatarefType::SET_VALUE, 1.0},
+            {std::vector<FMCKey>{FMCKey::PFP_EXEC, FMCKey::MCDU_EMPTY_TOP_RIGHT}, "CL650/CDU/" + cdu + "/exec", FMCDatarefType::SET_VALUE, 1.0},
+            {std::vector<FMCKey>{FMCKey::CLR, FMCKey::PFP_DEL}, "CL650/CDU/" + cdu + "/clr_del", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::MENU, "CL650/CDU/" + cdu + "/dspl_menu", FMCDatarefType::SET_VALUE, 1.0},
+            {std::vector<FMCKey>{FMCKey::PAGE_NEXT, FMCKey::MCDU_PAGE_UP}, "CL650/CDU/" + cdu + "/next", FMCDatarefType::SET_VALUE, 1.0},
+            {std::vector<FMCKey>{FMCKey::PAGE_PREV, FMCKey::MCDU_PAGE_DOWN}, "CL650/CDU/" + cdu + "/prev", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::MCDU_OVERFLY, "CL650/CDU/" + cdu + "/mfd_adv", FMCDatarefType::SET_VALUE, 1.0},
+
+            {FMCKey::BRIGHTNESS_UP, "CL650/CDU/" + cdu + "/brt_up"},
+            {FMCKey::BRIGHTNESS_DOWN, "CL650/CDU/" + cdu + "/brt_down"},
+
+            {FMCKey::KEY1, "CL650/CDU/" + cdu + "/char_1", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::KEY2, "CL650/CDU/" + cdu + "/char_2", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::KEY3, "CL650/CDU/" + cdu + "/char_3", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::KEY4, "CL650/CDU/" + cdu + "/char_4", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::KEY5, "CL650/CDU/" + cdu + "/char_5", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::KEY6, "CL650/CDU/" + cdu + "/char_6", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::KEY7, "CL650/CDU/" + cdu + "/char_7", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::KEY8, "CL650/CDU/" + cdu + "/char_8", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::KEY9, "CL650/CDU/" + cdu + "/char_9", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::KEY0, "CL650/CDU/" + cdu + "/char_0", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::PERIOD, "CL650/CDU/" + cdu + "/char_period", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::PLUSMINUS, "CL650/CDU/" + cdu + "/char_plus_minus", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::SLASH, "CL650/CDU/" + cdu + "/char_slash", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::SPACE, "CL650/CDU/" + cdu + "/char_space", FMCDatarefType::SET_VALUE, 1.0},
+
+            {FMCKey::KEYA, "CL650/CDU/" + cdu + "/char_A", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::KEYB, "CL650/CDU/" + cdu + "/char_B", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::KEYC, "CL650/CDU/" + cdu + "/char_C", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::KEYD, "CL650/CDU/" + cdu + "/char_D", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::KEYE, "CL650/CDU/" + cdu + "/char_E", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::KEYF, "CL650/CDU/" + cdu + "/char_F", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::KEYG, "CL650/CDU/" + cdu + "/char_G", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::KEYH, "CL650/CDU/" + cdu + "/char_H", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::KEYI, "CL650/CDU/" + cdu + "/char_I", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::KEYJ, "CL650/CDU/" + cdu + "/char_J", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::KEYK, "CL650/CDU/" + cdu + "/char_K", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::KEYL, "CL650/CDU/" + cdu + "/char_L", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::KEYM, "CL650/CDU/" + cdu + "/char_M", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::KEYN, "CL650/CDU/" + cdu + "/char_N", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::KEYO, "CL650/CDU/" + cdu + "/char_O", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::KEYP, "CL650/CDU/" + cdu + "/char_P", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::KEYQ, "CL650/CDU/" + cdu + "/char_Q", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::KEYR, "CL650/CDU/" + cdu + "/char_R", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::KEYS, "CL650/CDU/" + cdu + "/char_S", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::KEYT, "CL650/CDU/" + cdu + "/char_T", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::KEYU, "CL650/CDU/" + cdu + "/char_U", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::KEYV, "CL650/CDU/" + cdu + "/char_V", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::KEYW, "CL650/CDU/" + cdu + "/char_W", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::KEYX, "CL650/CDU/" + cdu + "/char_X", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::KEYY, "CL650/CDU/" + cdu + "/char_Y", FMCDatarefType::SET_VALUE, 1.0},
+            {FMCKey::KEYZ, "CL650/CDU/" + cdu + "/char_Z", FMCDatarefType::SET_VALUE, 1.0},
+
+            // Unmapped — no CL650 CDU equivalent
+            {FMCKey::PROG, ""},
+            {FMCKey::MCDU_EMPTY_BOTTOM_LEFT, ""},
+            {FMCKey::MCDU_FUEL_PRED, ""},
+            {FMCKey::MCDU_ATC_COMM, ""},
+            {FMCKey::MCDU_AIRPORT, ""},
+            {FMCKey::PFP_HOLD, ""},
+            {FMCKey::PFP_FIX, ""},
+            {FMCKey::PFP3_CLB, ""},
+            {FMCKey::PFP3_CRZ, ""},
+            {FMCKey::PFP3_DES, ""},
+            {FMCKey::PFP4_ATC, ""},
+            {FMCKey::PFP4_VNAV, ""},
+            {FMCKey::PFP4_FMC_COMM, ""},
+            {FMCKey::PFP7_ALTN, ""},
+            {FMCKey::PFP7_VNAV, ""},
+            {FMCKey::PFP7_FMC_COMM, ""},
+        };
+
+        it = cache.emplace(product->deviceVariant, std::move(buttons)).first;
+    }
+    return it->second;
+}
+
+const std::unordered_map<FMCKey, const FMCButtonDef *> &CL650FMCProfile::buttonKeyMap() const {
+    static std::unordered_map<FMCDeviceVariant, std::unordered_map<FMCKey, const FMCButtonDef *>> cache;
+
+    auto it = cache.find(product->deviceVariant);
+    if (it == cache.end()) {
+        std::unordered_map<FMCKey, const FMCButtonDef *> map;
+        const auto &buttons = buttonDefs();
+        for (const auto &button : buttons) {
+            std::visit([&](auto &&k) {
+                using T = std::decay_t<decltype(k)>;
+                if constexpr (std::is_same_v<T, FMCKey>) {
+                    map[k] = &button;
+                } else {
+                    for (const auto &key : k) {
+                        map[key] = &button;
+                    }
+                }
+            },
+                button.key);
+        }
+        it = cache.emplace(product->deviceVariant, std::move(map)).first;
+    }
+    return it->second;
+}
+
+const std::map<char, FMCTextColor> &CL650FMCProfile::colorMap() const {
+    // CL650 style byte: low nibble = color index, high nibble 0x80 = large font.
+    // Verified: 0x00=white, 0x01=cyan, 0x04=magenta (labels).
+    // 0x03=white (appears as normal text on INDENT page).
+    // 0x07=default/empty — leave unmapped so it falls through to COLOR_WHITE.
+    // Green/amber/red likely use indices 0x02/0x05/0x06 on pages we haven't dumped yet.
+    static const std::map<char, FMCTextColor> colMap = {
+        {0x00, FMCTextColor::COLOR_WHITE},
+        {0x01, FMCTextColor::COLOR_CYAN},
+        {0x02, FMCTextColor::COLOR_GREEN},
+        {0x03, FMCTextColor::COLOR_YELLOW},
+        {0x04, FMCTextColor::COLOR_GREEN},
+        {0x05, FMCTextColor::COLOR_MAGENTA},
+        {0x06, FMCTextColor::COLOR_AMBER},
+    };
+    return colMap;
+}
+
+void CL650FMCProfile::mapCharacter(std::vector<uint8_t> *buffer, uint8_t character, bool isFontSmall) {
+    switch (character) {
+        case '#':
+            buffer->insert(buffer->end(), FMCSpecialCharacter::OUTLINED_SQUARE.begin(), FMCSpecialCharacter::OUTLINED_SQUARE.end());
+            break;
+
+        case '<':
+            buffer->insert(buffer->end(), FMCSpecialCharacter::ARROW_LEFT.begin(), FMCSpecialCharacter::ARROW_LEFT.end());
+            break;
+
+        case '>':
+            buffer->insert(buffer->end(), FMCSpecialCharacter::ARROW_RIGHT.begin(), FMCSpecialCharacter::ARROW_RIGHT.end());
+            break;
+
+        case 30:
+            buffer->insert(buffer->end(), FMCSpecialCharacter::ARROW_UP.begin(), FMCSpecialCharacter::ARROW_UP.end());
+            break;
+
+        case 31:
+            buffer->insert(buffer->end(), FMCSpecialCharacter::ARROW_DOWN.begin(), FMCSpecialCharacter::ARROW_DOWN.end());
+            break;
+
+        case '`':
+            buffer->insert(buffer->end(), FMCSpecialCharacter::DEGREES.begin(), FMCSpecialCharacter::DEGREES.end());
+            break;
+
+        case '^':
+            buffer->insert(buffer->end(), FMCSpecialCharacter::TRIANGLE.begin(), FMCSpecialCharacter::TRIANGLE.end());
+            break;
+
+        default:
+            buffer->push_back(character);
+            break;
+    }
+}
+
+void CL650FMCProfile::updatePage(std::vector<std::vector<char>> &page) {
+    page = std::vector<std::vector<char>>(ProductFMC::PageLines, std::vector<char>(ProductFMC::PageCharsPerLine * ProductFMC::PageBytesPerChar, ' '));
+
+    auto datarefManager = Dataref::getInstance();
+    const std::string cdu = product->deviceVariant == FMCDeviceVariant::VARIANT_CAPTAIN ? "1" : "2";
+
+    // Replace unicode symbols with single-byte placeholders
+    const std::vector<std::pair<std::string, unsigned char>> symbols = {
+        {"\u2190", '<'},  // ← left arrow
+        {"\u2192", '>'},  // → right arrow
+        {"\u2191", 30},   // ↑ up arrow
+        {"\u2193", 31},   // ↓ down arrow
+        {"\u2610", '#'},  // ☐ ballot box
+        {"\u00B0", '`'},  // ° degree
+        {"\u0394", '^'},  // Δ delta (looks like triangle)
+        // Additional arrows
+        {"\u2194", '<'},  // ↔ left-right
+        {"\u2196", '<'},  // ↖ NW
+        {"\u2197", '>'},  // ↗ NE
+        {"\u2198", '>'},  // ↘ SE
+        {"\u2199", '<'},  // ↙ SW
+        {"\u21E6", '<'},  // ⇦ thinner left
+        {"\u21E8", '>'},  // ⇨ thinner right
+        {"\u21E7", 30},   // ⇧ thinner up
+        {"\u21E9", 31},   // ⇩ thinner down
+        // Box-drawing (light)
+        {"\u2500", '-'},  // ─ horizontal
+        {"\u2502", '|'},  // │ vertical
+        {"\u250C", '+'},  // ┌ down-right
+        {"\u2510", '+'},  // ┐ down-left
+        {"\u2514", '+'},  // └ up-right
+        {"\u2518", '+'},  // ┘ up-left
+        {"\u251C", '|'},  // ├ vertical-right (T-junction left)
+        {"\u2524", '|'},  // ┤ vertical-left (T-junction right)
+        {"\u252C", '+'},  // ┬ down-horizontal
+        {"\u2534", '+'},  // ┴ up-horizontal
+        {"\u253C", '+'},  // ┼ vertical-horizontal
+        // Box-drawing (heavy)
+        {"\u2550", '='},  // ═ double horizontal
+        {"\u2551", '|'},  // ║ double vertical
+        {"\u2554", '+'},  // ╔ double down-right
+        {"\u2557", '+'},  // ╗ double down-left
+        {"\u255A", '+'},  // ╚ double up-right
+        {"\u255D", '+'},  // ╝ double up-left
+        {"\u2560", '+'},  // ╠ double vertical-right
+        {"\u2563", '+'},  // ╣ double vertical-left
+        {"\u2566", '+'},  // ╦ double down-horizontal
+        {"\u2569", '+'},  // ╩ double up-horizontal
+        {"\u256C", '+'},  // ╬ double vertical-horizontal
+        // Arcs / rounded corners
+        {"\u256D", '|'},  // ╭ arc down-right
+        {"\u256E", '|'},  // ╮ arc down-left
+        {"\u256F", '|'},  // ╯ arc up-left
+        {"\u2570", '|'},  // ╰ arc up-right
+        // Brackets / corners
+        {"\u23A1", '+'},  // ⎡
+        {"\u23A4", '+'},  // ⎤
+        {"\u23A7", '{'},  // ⎧ curly
+        {"\u23AB", '}'},  // ⎫ curly
+        {"\u27E6", '['},  // ⟦
+        {"\u27E7", ']'},  // ⟧
+    };
+
+    static constexpr int ScreenLines = 14; // text_line0..text_line13; line 14 is a message line we skip
+
+    for (int lineNum = 0; lineNum < ScreenLines; ++lineNum) {
+        std::string textDataref = "CL650/CDU/" + cdu + "/screen/text_line" + std::to_string(lineNum);
+        std::string styleDataref = "CL650/CDU/" + cdu + "/screen/style_line" + std::to_string(lineNum);
+
+        std::string text = datarefManager->getCached<std::string>(textDataref.c_str());
+        if (text.empty()) {
+            continue;
+        }
+
+        // style_lineN displayed as int[24] in DataRefEditor but stored as byte array
+        std::vector<unsigned char> styleBytes = datarefManager->getCached<std::vector<unsigned char>>(styleDataref.c_str());
+
+        // Replace unicode symbols with single-byte placeholders
+        for (const auto &symbol : symbols) {
+            size_t pos = 0;
+            while ((pos = text.find(symbol.first, pos)) != std::string::npos) {
+                text.replace(pos, symbol.first.length(), std::string(1, static_cast<char>(symbol.second)));
+                pos += 1;
+            }
+        }
+
+        // Map remaining high-byte characters (CP437 box-drawing, etc.) to ASCII equivalents
+        for (size_t i = 0; i < text.size(); ++i) {
+            unsigned char c = static_cast<unsigned char>(text[i]);
+            if (c <= 127) { continue; }
+            switch (c) {
+                // CP437 box-drawing
+                case 0xB0: case 0xB1: case 0xB2: text[i] = ' '; break;
+                case 0xB3: case 0xDD: case 0xDE: text[i] = '|'; break;
+                case 0xC4: case 0xDC: case 0xDF: text[i] = '-'; break;
+                case 0xBA:                     text[i] = '|'; break;
+                case 0xCD:                     text[i] = '='; break;
+                // CP437 single-line box corners + junctions → +
+                case 0xBF: case 0xC0: case 0xD9: case 0xDA:
+                case 0xB4: case 0xC3: case 0xC1: case 0xC2: case 0xC5:
+                // CP437 double-line and mixed corners → +
+                case 0xB5: case 0xB6: case 0xB7: case 0xB8: case 0xB9:
+                case 0xBB: case 0xBC: case 0xBD: case 0xBE:
+                case 0xC6: case 0xC7: case 0xC8: case 0xC9:
+                case 0xCA: case 0xCB: case 0xCC: case 0xCE: case 0xCF:
+                case 0xD0: case 0xD1: case 0xD2: case 0xD3: case 0xD4:
+                case 0xD5: case 0xD6: case 0xD7: case 0xD8:
+                    text[i] = '+'; break;
+                case 0xDB:                     text[i] = '#'; break;
+                default:                       text[i] = ' '; break;
+            }
+        }
+
+        for (int i = 0; i < text.size() && i < ProductFMC::PageCharsPerLine; ++i) {
+            char c = text[i];
+            if (c == 0x00 || c == ' ') {
+                continue;
+            }
+
+            bool fontSmall = false;
+            unsigned char styleByte = (i < styleBytes.size()) ? styleBytes[i] : 0x00;
+            fontSmall = (styleByte & 0xF0) == 0x00;
+
+            unsigned char colorIdx = styleByte & 0x0F;
+
+            product->writeLineToPage(page, lineNum, i, std::string(1, c), colorIdx, fontSmall);
+        }
+    }
+}
+
+void CL650FMCProfile::buttonPressed(const FMCButtonDef *button, XPLMCommandPhase phase) {
+    if (!button || button->dataref.empty() || phase == xplm_CommandContinue) {
+        return;
+    }
+
+    auto datarefManager = Dataref::getInstance();
+    if (button->datarefType == FMCDatarefType::SET_VALUE || button->datarefType == FMCDatarefType::SET_VALUE_PHASED) {
+        double value = std::fabs(button->value) < std::numeric_limits<double>::epsilon() ? 1.0 : button->value;
+        if (button->datarefType == FMCDatarefType::SET_VALUE && phase != xplm_CommandBegin) {
+            return;
+        }
+
+        datarefManager->set<double>(button->dataref.c_str(), phase == xplm_CommandBegin ? value : 0.0);
+    } else if (phase == xplm_CommandBegin && button->datarefType == FMCDatarefType::ADJUST_VALUE) {
+        double currentValue = datarefManager->get<double>(button->dataref.c_str());
+        datarefManager->set<double>(button->dataref.c_str(), currentValue + button->value);
+    } else if (phase == xplm_CommandBegin && button->datarefType == FMCDatarefType::EXECUTE_MULTIPLE_CMD_ONCE) {
+        std::stringstream ss(button->dataref);
+        std::string item;
+        std::vector<std::string> commands;
+        while (std::getline(ss, item, ',')) {
+            commands.push_back(item);
+        }
+
+        for (const auto &cmd : commands) {
+            datarefManager->executeCommand(cmd.c_str());
+        }
+    } else if (phase == xplm_CommandBegin && button->datarefType == FMCDatarefType::EXECUTE_CMD_ONCE) {
+        datarefManager->executeCommand(button->dataref.c_str());
+    } else {
+        datarefManager->executeCommand(button->dataref.c_str(), phase);
+    }
+}

--- a/src/include/products/fmc/profiles/cl650-fmc-profile.h
+++ b/src/include/products/fmc/profiles/cl650-fmc-profile.h
@@ -1,0 +1,21 @@
+#ifndef CL650_FMC_PROFILE_H
+#define CL650_FMC_PROFILE_H
+
+#include "fmc-aircraft-profile.h"
+
+class CL650FMCProfile : public FMCAircraftProfile {
+    public:
+        CL650FMCProfile(ProductFMC *product);
+        ~CL650FMCProfile();
+
+        static bool IsEligible();
+        const std::vector<std::string> &displayDatarefs() const override;
+        const std::vector<FMCButtonDef> &buttonDefs() const override;
+        const std::unordered_map<FMCKey, const FMCButtonDef *> &buttonKeyMap() const override;
+        const std::map<char, FMCTextColor> &colorMap() const override;
+        void mapCharacter(std::vector<uint8_t> *buffer, uint8_t character, bool isFontSmall) override;
+        void updatePage(std::vector<std::vector<char>> &page) override;
+        void buttonPressed(const FMCButtonDef *button, XPLMCommandPhase phase) override;
+};
+
+#endif // CL650_FMC_PROFILE_H

--- a/src/include/products/fmc/profiles/q4xp-fmc-profile.cpp
+++ b/src/include/products/fmc/profiles/q4xp-fmc-profile.cpp
@@ -1,0 +1,371 @@
+#include "q4xp-fmc-profile.h"
+
+#include "config.h"
+#include "dataref.h"
+#include "product-fmc.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <sstream>
+
+Q4XPFMCProfile::Q4XPFMCProfile(ProductFMC *product) : FMCAircraftProfile(product) {
+    product->setAllLedsEnabled(false);
+
+    Dataref::getInstance()->monitorExistingDataref<std::vector<float>>("FJS/Q4XP/Lights/panelText_LIT", [product](const std::vector<float> &brightness) {
+        if (brightness.size() <= 2) {
+            return;
+        }
+
+        uint8_t target = static_cast<uint8_t>(std::clamp(brightness[2], 0.0f, 1.0f) * 255);
+        product->setLedBrightness(FMCLed::BACKLIGHT, target);
+    },
+        this);
+
+    auto font = Font::GlyphData("Q4XP.xpwwf", product->identifierByte, product->hardwareType);
+    if (!font.empty()) {
+        for (auto &packet : font) {
+            product->writeData(packet);
+        }
+    } else {
+        product->setFont(FontVariant::Default);
+    }
+}
+
+Q4XPFMCProfile::~Q4XPFMCProfile() {
+}
+
+bool Q4XPFMCProfile::IsEligible() {
+    return Dataref::getInstance()->exists("FJS/Q4XP/cdu1/text_line_0");
+}
+
+const std::vector<std::string> &Q4XPFMCProfile::displayDatarefs() const {
+    static std::unordered_map<FMCDeviceVariant, std::vector<std::string>> cache;
+
+    auto it = cache.find(product->deviceVariant);
+    if (it == cache.end()) {
+        const std::string cdu = product->deviceVariant == FMCDeviceVariant::VARIANT_CAPTAIN ? "cdu1" : "cdu2";
+        std::vector<std::string> refs;
+        static constexpr int ScreenLines = 11;
+        for (int i = 0; i < ScreenLines; ++i) {
+            refs.push_back("FJS/Q4XP/" + cdu + "/text_line_" + std::to_string(i));
+            refs.push_back("FJS/Q4XP/" + cdu + "/style_line_" + std::to_string(i));
+        }
+        it = cache.emplace(product->deviceVariant, std::move(refs)).first;
+    }
+    return it->second;
+}
+
+const std::vector<FMCButtonDef> &Q4XPFMCProfile::buttonDefs() const {
+    static std::unordered_map<FMCDeviceVariant, std::vector<FMCButtonDef>> cache;
+
+    auto it = cache.find(product->deviceVariant);
+    if (it == cache.end()) {
+        const std::string fms = product->deviceVariant == FMCDeviceVariant::VARIANT_CAPTAIN ? "fms1" : "fms2";
+
+        std::vector<FMCButtonDef> buttons = {
+            {FMCKey::LSK1L, "FJS/Q4XP/" + fms + "/lsk_l1", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::LSK2L, "FJS/Q4XP/" + fms + "/lsk_l2", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::LSK3L, "FJS/Q4XP/" + fms + "/lsk_l3", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::LSK4L, "FJS/Q4XP/" + fms + "/lsk_l4", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::LSK5L, "FJS/Q4XP/" + fms + "/lsk_l5", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::LSK1R, "FJS/Q4XP/" + fms + "/lsk_r1", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::LSK2R, "FJS/Q4XP/" + fms + "/lsk_r2", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::LSK3R, "FJS/Q4XP/" + fms + "/lsk_r3", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::LSK4R, "FJS/Q4XP/" + fms + "/lsk_r4", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::LSK5R, "FJS/Q4XP/" + fms + "/lsk_r5", FMCDatarefType::EXECUTE_CMD_ONCE},
+
+            // UNS-1 only has 5 LSKs per side — LSK6 mapped empty
+            {FMCKey::LSK6L, ""},
+            {FMCKey::LSK6R, ""},
+
+            {std::vector<FMCKey>{FMCKey::MCDU_DIR, FMCKey::PFP_INIT_REF}, "FJS/Q4XP/" + fms + "/dto", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {std::vector<FMCKey>{FMCKey::MCDU_PERF, FMCKey::PFP3_N1_LIMIT}, "FJS/Q4XP/" + fms + "/perf", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::MCDU_DATA, "FJS/Q4XP/" + fms + "/data", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::MCDU_FPLN, "FJS/Q4XP/" + fms + "/fpl", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::PFP_LEGS, "FJS/Q4XP/" + fms + "/fpl", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::PFP_ROUTE, "FJS/Q4XP/" + fms + "/fpl", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {std::vector<FMCKey>{FMCKey::MCDU_RAD_NAV, FMCKey::PFP4_NAV_RAD, FMCKey::PFP7_NAV_RAD}, "FJS/Q4XP/" + fms + "/nav", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::MCDU_FUEL_PRED, "FJS/Q4XP/" + fms + "/fuel", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {std::vector<FMCKey>{FMCKey::MCDU_ATC_COMM, FMCKey::PFP4_ATC}, "FJS/Q4XP/" + fms + "/tune", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {std::vector<FMCKey>{FMCKey::MCDU_INIT, FMCKey::PFP4_VNAV, FMCKey::PFP7_VNAV}, "FJS/Q4XP/" + fms + "/vnav", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {std::vector<FMCKey>{FMCKey::MCDU_AIRPORT, FMCKey::PFP_DEP_ARR}, "FJS/Q4XP/" + fms + "/list", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::MENU, "FJS/Q4XP/" + fms + "/menu", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::PFP_EXEC, "FJS/Q4XP/" + fms + "/key_enter", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::MCDU_OVERFLY, "FJS/Q4XP/" + fms + "/key_enter", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::MCDU_EMPTY_TOP_RIGHT, "FJS/Q4XP/" + fms + "/pwr", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {std::vector<FMCKey>{FMCKey::CLR, FMCKey::PFP_DEL}, "FJS/Q4XP/" + fms + "/key_back", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::KEY0, "FJS/Q4XP/" + fms + "/key_0", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::KEY1, "FJS/Q4XP/" + fms + "/key_1", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::KEY2, "FJS/Q4XP/" + fms + "/key_2", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::KEY3, "FJS/Q4XP/" + fms + "/key_3", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::KEY4, "FJS/Q4XP/" + fms + "/key_4", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::KEY5, "FJS/Q4XP/" + fms + "/key_5", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::KEY6, "FJS/Q4XP/" + fms + "/key_6", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::KEY7, "FJS/Q4XP/" + fms + "/key_7", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::KEY8, "FJS/Q4XP/" + fms + "/key_8", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::KEY9, "FJS/Q4XP/" + fms + "/key_9", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::KEYA, "FJS/Q4XP/" + fms + "/key_A", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::KEYB, "FJS/Q4XP/" + fms + "/key_B", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::KEYC, "FJS/Q4XP/" + fms + "/key_C", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::KEYD, "FJS/Q4XP/" + fms + "/key_D", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::KEYE, "FJS/Q4XP/" + fms + "/key_E", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::KEYF, "FJS/Q4XP/" + fms + "/key_F", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::KEYG, "FJS/Q4XP/" + fms + "/key_G", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::KEYH, "FJS/Q4XP/" + fms + "/key_H", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::KEYI, "FJS/Q4XP/" + fms + "/key_I", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::KEYJ, "FJS/Q4XP/" + fms + "/key_J", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::KEYK, "FJS/Q4XP/" + fms + "/key_K", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::KEYL, "FJS/Q4XP/" + fms + "/key_L", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::KEYM, "FJS/Q4XP/" + fms + "/key_M", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::KEYN, "FJS/Q4XP/" + fms + "/key_N", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::KEYO, "FJS/Q4XP/" + fms + "/key_O", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::KEYP, "FJS/Q4XP/" + fms + "/key_P", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::KEYQ, "FJS/Q4XP/" + fms + "/key_Q", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::KEYR, "FJS/Q4XP/" + fms + "/key_R", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::KEYS, "FJS/Q4XP/" + fms + "/key_S", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::KEYT, "FJS/Q4XP/" + fms + "/key_T", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::KEYU, "FJS/Q4XP/" + fms + "/key_U", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::KEYV, "FJS/Q4XP/" + fms + "/key_V", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::KEYW, "FJS/Q4XP/" + fms + "/key_W", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::KEYX, "FJS/Q4XP/" + fms + "/key_X", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::KEYY, "FJS/Q4XP/" + fms + "/key_Y", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::KEYZ, "FJS/Q4XP/" + fms + "/key_Z", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::PLUSMINUS, "FJS/Q4XP/" + fms + "/plusminus", FMCDatarefType::EXECUTE_CMD_ONCE},
+
+            // Arrows: UP=prev, DOWN=next, LEFT=back
+            {FMCKey::MCDU_PAGE_UP, "FJS/Q4XP/" + fms + "/prev", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::MCDU_PAGE_DOWN, "FJS/Q4XP/" + fms + "/next", FMCDatarefType::EXECUTE_CMD_ONCE},
+            {FMCKey::PAGE_PREV, "FJS/Q4XP/" + fms + "/back", FMCDatarefType::EXECUTE_CMD_ONCE},
+
+            // Remaining keys — no UNS-1 equivalent
+            {FMCKey::BRIGHTNESS_UP, ""},
+            {FMCKey::BRIGHTNESS_DOWN, ""},
+            {FMCKey::PAGE_NEXT, ""},
+            {FMCKey::MCDU_EMPTY_BOTTOM_LEFT, ""},
+            {FMCKey::MCDU_SEC_FPLN, ""},
+            {FMCKey::SLASH, ""},
+            {FMCKey::PERIOD, ""},
+            {FMCKey::SPACE, ""},
+            {FMCKey::PROG, ""},
+            {FMCKey::PFP_HOLD, ""},
+            {FMCKey::PFP_FIX, ""},
+            {FMCKey::PFP3_CLB, ""},
+            {FMCKey::PFP3_CRZ, ""},
+            {FMCKey::PFP3_DES, ""},
+            {FMCKey::PFP4_FMC_COMM, ""},
+            {FMCKey::PFP7_ALTN, ""},
+            {FMCKey::PFP7_FMC_COMM, ""},
+        };
+
+        it = cache.emplace(product->deviceVariant, std::move(buttons)).first;
+    }
+    return it->second;
+}
+
+const std::unordered_map<FMCKey, const FMCButtonDef *> &Q4XPFMCProfile::buttonKeyMap() const {
+    static std::unordered_map<FMCDeviceVariant, std::unordered_map<FMCKey, const FMCButtonDef *>> cache;
+
+    auto it = cache.find(product->deviceVariant);
+    if (it == cache.end()) {
+        std::unordered_map<FMCKey, const FMCButtonDef *> map;
+        const auto &buttons = buttonDefs();
+        for (const auto &button : buttons) {
+            std::visit([&](auto &&k) {
+                using T = std::decay_t<decltype(k)>;
+                if constexpr (std::is_same_v<T, FMCKey>) {
+                    map[k] = &button;
+                } else {
+                    for (const auto &key : k) {
+                        map[key] = &button;
+                    }
+                }
+            },
+                button.key);
+        }
+        it = cache.emplace(product->deviceVariant, std::move(map)).first;
+    }
+    return it->second;
+}
+
+const std::map<char, FMCTextColor> &Q4XPFMCProfile::colorMap() const {
+    static const std::map<char, FMCTextColor> colMap = {
+        {0x00, FMCTextColor::COLOR_WHITE},
+        {0x01, FMCTextColor::COLOR_WHITE},
+        {0x02, FMCTextColor::COLOR_GREEN},
+        {0x03, FMCTextColor::COLOR_YELLOW},
+        {0x04, FMCTextColor::COLOR_GREEN},
+        {0x05, FMCTextColor::COLOR_MAGENTA},
+        {0x06, FMCTextColor::COLOR_GREEN},
+        {0x07, FMCTextColor::COLOR_CYAN},
+        {0x0B, FMCTextColor::COLOR_GREEN},
+        {0x40, FMCTextColor::withBackgroundColor(FMCTextColor::COLOR_BLACK, FMCTextColor::COLOR_WHITE)},  // inverted (ACCEPT)
+    };
+    return colMap;
+}
+
+void Q4XPFMCProfile::mapCharacter(std::vector<uint8_t> *buffer, uint8_t character, bool isFontSmall) {
+    switch (character) {
+        case '#':
+            buffer->insert(buffer->end(), FMCSpecialCharacter::OUTLINED_SQUARE.begin(), FMCSpecialCharacter::OUTLINED_SQUARE.end());
+            break;
+
+        case '<':
+            buffer->insert(buffer->end(), FMCSpecialCharacter::ARROW_LEFT.begin(), FMCSpecialCharacter::ARROW_LEFT.end());
+            break;
+
+        case '>':
+            buffer->insert(buffer->end(), FMCSpecialCharacter::ARROW_RIGHT.begin(), FMCSpecialCharacter::ARROW_RIGHT.end());
+            break;
+
+        case 30:
+            buffer->insert(buffer->end(), FMCSpecialCharacter::ARROW_UP.begin(), FMCSpecialCharacter::ARROW_UP.end());
+            break;
+
+        case 31:
+            buffer->insert(buffer->end(), FMCSpecialCharacter::ARROW_DOWN.begin(), FMCSpecialCharacter::ARROW_DOWN.end());
+            break;
+
+        case '`':
+            buffer->insert(buffer->end(), FMCSpecialCharacter::DEGREES.begin(), FMCSpecialCharacter::DEGREES.end());
+            break;
+
+        case '^':
+            buffer->insert(buffer->end(), FMCSpecialCharacter::TRIANGLE.begin(), FMCSpecialCharacter::TRIANGLE.end());
+            break;
+
+        default:
+            buffer->push_back(character);
+            break;
+    }
+}
+
+void Q4XPFMCProfile::updatePage(std::vector<std::vector<char>> &page) {
+    page = std::vector<std::vector<char>>(ProductFMC::PageLines, std::vector<char>(ProductFMC::PageCharsPerLine * ProductFMC::PageBytesPerChar, ' '));
+
+    auto datarefManager = Dataref::getInstance();
+    const std::string cdu = product->deviceVariant == FMCDeviceVariant::VARIANT_CAPTAIN ? "cdu1" : "cdu2";
+
+    // Replace unicode symbols with single-byte placeholders
+    const std::vector<std::pair<std::string, unsigned char>> symbols = {
+        {"\u2190", '<'},  {"\u2192", '>'},  {"\u2191", 30},  {"\u2193", 31},
+        {"\u2610", '#'},  {"\u00B0", '`'},  {"\u0394", '^'},
+        {"\u2194", '<'},  {"\u2196", '<'},  {"\u2197", '>'},  {"\u2198", '>'},  {"\u2199", '<'},
+        {"\u21E6", '<'},  {"\u21E8", '>'},  {"\u21E7", 30},  {"\u21E9", 31},
+        {"\u2500", '-'},  {"\u2502", '|'},  {"\u250C", '+'}, {"\u2510", '+'}, {"\u2514", '+'}, {"\u2518", '+'},
+        {"\u251C", '|'},  {"\u2524", '|'},  {"\u252C", '+'}, {"\u2534", '+'}, {"\u253C", '+'},
+        {"\u2550", '='},  {"\u2551", '|'},  {"\u2554", '+'}, {"\u2557", '+'}, {"\u255A", '+'}, {"\u255D", '+'},
+        {"\u2560", '+'},  {"\u2563", '+'},  {"\u2566", '+'}, {"\u2569", '+'}, {"\u256C", '+'},
+        {"\u256D", '|'},  {"\u256E", '|'},  {"\u256F", '|'},  {"\u2570", '|'},
+        {"\u23A1", '+'},  {"\u23A4", '+'},  {"\u23A7", '{'},  {"\u23AB", '}'},
+        {"\u27E6", '['},  {"\u27E7", ']'},
+    };
+
+    static constexpr int ScreenLines = 11;
+
+    for (int lineNum = 0; lineNum < ScreenLines; ++lineNum) {
+        std::string textDataref = "FJS/Q4XP/" + cdu + "/text_line_" + std::to_string(lineNum);
+        std::string styleDataref = "FJS/Q4XP/" + cdu + "/style_line_" + std::to_string(lineNum);
+
+        std::string text = datarefManager->getCached<std::string>(textDataref.c_str());
+        if (text.empty()) {
+            continue;
+        }
+
+        std::vector<unsigned char> styleBytes = datarefManager->getCached<std::vector<unsigned char>>(styleDataref.c_str());
+
+        for (const auto &symbol : symbols) {
+            size_t pos = 0;
+            while ((pos = text.find(symbol.first, pos)) != std::string::npos) {
+                text.replace(pos, symbol.first.length(), std::string(1, static_cast<char>(symbol.second)));
+                pos += 1;
+            }
+        }
+
+        // Map remaining high-byte characters to ASCII equivalents
+        for (size_t i = 0; i < text.size(); ++i) {
+            unsigned char c = static_cast<unsigned char>(text[i]);
+            if (c <= 127) { continue; }
+            switch (c) {
+                case 0xB0: case 0xB1: case 0xB2: text[i] = ' '; break;
+                case 0xB3: case 0xDD: case 0xDE: text[i] = '|'; break;
+                case 0xC4: case 0xDC: case 0xDF: text[i] = '-'; break;
+                case 0xBA:                     text[i] = '|'; break;
+                case 0xCD:                     text[i] = '='; break;
+                case 0xBF: case 0xC0: case 0xD9: case 0xDA:
+                case 0xB4: case 0xC3: case 0xC1: case 0xC2: case 0xC5:
+                case 0xB5: case 0xB6: case 0xB7: case 0xB8: case 0xB9:
+                case 0xBB: case 0xBC: case 0xBD: case 0xBE:
+                case 0xC6: case 0xC7: case 0xC8: case 0xC9:
+                case 0xCA: case 0xCB: case 0xCC: case 0xCE: case 0xCF:
+                case 0xD0: case 0xD1: case 0xD2: case 0xD3: case 0xD4:
+                case 0xD5: case 0xD6: case 0xD7: case 0xD8:
+                    text[i] = '+'; break;
+                case 0xDB: text[i] = '#'; break;
+                default:   text[i] = ' '; break;
+            }
+        }
+
+        int displayLine = lineNum;
+        if (displayLine >= ProductFMC::PageLines) {
+            break;
+        }
+
+        for (int i = 0; i < text.size() && i < ProductFMC::PageCharsPerLine; ++i) {
+            char c = text[i];
+            if (c == 0x00) {
+                continue;
+            }
+
+            bool fontSmall = false;
+            unsigned char styleByte = (i < styleBytes.size()) ? styleBytes[i] : 0x00;
+            fontSmall = (styleByte & 0xF0) == 0x00;
+
+            bool isInverted = (styleByte & 0x40);
+            if (c == ' ' && !isInverted) {
+                continue;
+            }
+
+            unsigned char colorIdx = styleByte & 0x0F;
+            if (styleByte & 0x40) {
+                colorIdx = 0x40;  // inverted/reverse video
+            }
+
+            product->writeLineToPage(page, displayLine, i, std::string(1, c), colorIdx, fontSmall);
+        }
+    }
+}
+
+void Q4XPFMCProfile::buttonPressed(const FMCButtonDef *button, XPLMCommandPhase phase) {
+    if (!button || button->dataref.empty() || phase == xplm_CommandContinue) {
+        return;
+    }
+
+    auto datarefManager = Dataref::getInstance();
+    if (button->datarefType == FMCDatarefType::SET_VALUE || button->datarefType == FMCDatarefType::SET_VALUE_PHASED) {
+        double value = std::fabs(button->value) < std::numeric_limits<double>::epsilon() ? 1.0 : button->value;
+        if (button->datarefType == FMCDatarefType::SET_VALUE && phase != xplm_CommandBegin) {
+            return;
+        }
+
+        datarefManager->set<double>(button->dataref.c_str(), phase == xplm_CommandBegin ? value : 0.0);
+    } else if (phase == xplm_CommandBegin && button->datarefType == FMCDatarefType::ADJUST_VALUE) {
+        double currentValue = datarefManager->get<double>(button->dataref.c_str());
+        datarefManager->set<double>(button->dataref.c_str(), currentValue + button->value);
+    } else if (phase == xplm_CommandBegin && button->datarefType == FMCDatarefType::EXECUTE_MULTIPLE_CMD_ONCE) {
+        std::stringstream ss(button->dataref);
+        std::string item;
+        std::vector<std::string> commands;
+        while (std::getline(ss, item, ',')) {
+            commands.push_back(item);
+        }
+
+        for (const auto &cmd : commands) {
+            datarefManager->executeCommand(cmd.c_str());
+        }
+    } else if (phase == xplm_CommandBegin && button->datarefType == FMCDatarefType::EXECUTE_CMD_ONCE) {
+        datarefManager->executeCommand(button->dataref.c_str());
+    } else {
+        datarefManager->executeCommand(button->dataref.c_str(), phase);
+    }
+}

--- a/src/include/products/fmc/profiles/q4xp-fmc-profile.h
+++ b/src/include/products/fmc/profiles/q4xp-fmc-profile.h
@@ -1,0 +1,21 @@
+#ifndef Q4XP_FMC_PROFILE_H
+#define Q4XP_FMC_PROFILE_H
+
+#include "fmc-aircraft-profile.h"
+
+class Q4XPFMCProfile : public FMCAircraftProfile {
+    public:
+        Q4XPFMCProfile(ProductFMC *product);
+        ~Q4XPFMCProfile();
+
+        static bool IsEligible();
+        const std::vector<std::string> &displayDatarefs() const override;
+        const std::vector<FMCButtonDef> &buttonDefs() const override;
+        const std::unordered_map<FMCKey, const FMCButtonDef *> &buttonKeyMap() const override;
+        const std::map<char, FMCTextColor> &colorMap() const override;
+        void mapCharacter(std::vector<uint8_t> *buffer, uint8_t character, bool isFontSmall) override;
+        void updatePage(std::vector<std::vector<char>> &page) override;
+        void buttonPressed(const FMCButtonDef *button, XPLMCommandPhase phase) override;
+};
+
+#endif // Q4XP_FMC_PROFILE_H


### PR DESCRIPTION
 Adds WINCTRL hardware support for the Hot Start CL650 and FlyJSim Q4XP.

  CL650:
  - Adds CL650 FMC/CDU profile
  - Adds CL650 FCU/EFIS profile
  - Maps CDU screen brightness to CL650/CDU/*/screen/brt
  - Maps CDU key/backlight brightness to CL650/lamps/integ/1A1FS_cdu*
  - Maps MCDU brightness up/down buttons to CL650/CDU/*/brt_up and brt_down
  - Maps FCU/EFIS backlight to CL650/lamps/integ/P2LM_plt_glrshld
  - Adds CL650 MCDU button mappings:
    - F-PLN -> legs
    - SEC F-PLN -> fpln
    - empty top-right key -> exec
  - Adds CL650 color/style and character mapping support

  Q4XP:
  - Adds Q4XP FMC/CDU profile
  - Adds Q4XP FCU/EFIS profile
  - Maps Q4XP CDU display text/style datarefs
  - Adds Q4XP UNS/FMS button mappings
  - Adds Q4XP character replacement and color/style mapping
  - Adds basic FCU display values for speed, heading, altitude, vertical speed, and baro
  - Adds FCU/EFIS button mappings using Q4XP and standard X-Plane commands

  Tested with WINCTRL MCDU and FCU/EFIS hardware in X-Plane 12 on Linux (CachyOS) using the Hot Start CL650 and Q4XP.

  Build tested with:
  cmake --build build --parallel
